### PR TITLE
최지훈 [SWEA] 1949. 등산로 조성

### DIFF
--- a/최지훈/day01/Day01_등산로조성.java
+++ b/최지훈/day01/Day01_등산로조성.java
@@ -1,0 +1,86 @@
+import java.io.*;
+import java.util.*;
+
+public class Solution {
+
+    static StringBuilder sb = new StringBuilder();
+    static int T, N, K;
+    static int[][] board;
+    static int maxMt;
+    static int minMt;
+    static int maxCnt;
+
+    static int[] dx = { -1, 1, 0, 0 };
+    static int[] dy = { 0, 0, -1, 1 };
+
+    // 이전 좌표, 현재 좌표, 깎음 여부, 나아간 거리, 방문
+    static void dfs(int x, int y, boolean cut, int dist, boolean[][] visited) {
+        maxCnt = Math.max(maxCnt, dist);
+
+        for (int d = 0; d < 4; d++) {
+            int nx = x + dx[d];
+            int ny = y + dy[d];
+
+            if (nx < 0 || nx >= N || ny < 0 || ny >= N || visited[nx][ny])
+                continue;
+
+            if(board[x][y] > board[nx][ny]) {
+                visited[nx][ny] = true;
+                dfs(nx, ny, cut, dist + 1, visited);
+                visited[nx][ny] = false;
+            }
+            else if(!cut && board[x][y] > board[nx][ny] - K) {
+                int origin = board[nx][ny];
+                board[nx][ny] = board[x][y] - 1; // 가장 작게 1만 컷팅
+                visited[nx][ny] = true;
+                dfs(nx, ny, true, dist + 1, visited);
+                visited[nx][ny] = false;
+                board[nx][ny] = origin;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        //System.setIn(new FileInputStream("src/input.txt"));
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        T = Integer.parseInt(st.nextToken());
+        for (int t = 1; t <= T; t++) {
+            st = new StringTokenizer(br.readLine());
+            N = Integer.parseInt(st.nextToken());
+            K = Integer.parseInt(st.nextToken());
+            maxMt = Integer.MIN_VALUE;
+            minMt = Integer.MAX_VALUE;
+            maxCnt = Integer.MIN_VALUE;
+
+            board = new int[N][N];
+
+            for (int i = 0; i < N; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 0; j < N; j++) {
+                    board[i][j] = Integer.parseInt(st.nextToken());
+                    maxMt = Math.max(maxMt, board[i][j]);
+                    minMt = Math.min(minMt, board[i][j]);
+                }
+            }
+
+            sb.append("#").append(t).append(" ");
+
+            for (int i = 0; i < N; i++) {
+                for (int j = 0; j < N; j++) {
+                    if (maxMt == board[i][j]) {
+                        boolean[][] visited = new boolean[N][N];
+                        visited[i][j] = true;
+                        dfs(i, j, false, 1, visited);
+                    }
+                }
+            }
+
+            sb.append(maxCnt).append("\n");
+        }
+
+        System.out.println(sb);
+        br.close();
+    }
+}


### PR DESCRIPTION
<aside>

### 문제 풀이 단계

- [x]  문제를 3회독 및 이해
- [x]  문제를 익숙한 용어로 재정의
- [x]  어떻게 해결할지 계획을 세운다.
- [x]  계획을 검증한다.
    - [x]  가장 작은 테케를 가지고 시뮬레이션
    - [x]  시간 복잡도 확인
    - [x]  오픈 테케 및 엣지 테케 만들고 시뮬레이션 및 시간 복잡도 확인
- [x]  문제 풀이
- [x]  어떻게 풀었는지 돌아보고, 개선할 방법이 있는지 찾아본다
</aside>

---

### 문제 풀이

<aside>

**문제 정리**

1. 가장 높은 곳에서 시작해서 현재 위치보다 작은 곳으로만 나아가서 가장 멀리 나갔을 때 길의 길이를 구하는 문제.
2. 산은 한번 깎을 수 있는데 K 이하로 깎아서 현재 위치보다 높이가 작아지면 이동이 가능.

---

**시간 복잡도 계산**

1. 하나의 테스트 케이스에 대해서 최대 5번의 초기 dfs 실행 (가장 높은 봉우리는 5개 이므로) & n*n 만큼 순회(거의 무시 가능)
    - 이때, dfs의 최악의 복잡도는 모든 곳을 탐색 → n*n
    - 방향 4곳으로 dfs를 돌리므로 4 * n * n
2. 따라서 최종 최악의 시간 복잡도는 O(5 * 4 * n * n) ⇒ n≤8 이므로 5 * 4 * 64 = 1280
3. 테케는 51개 이므로 51 * 1280 = 65280 으로 충분
</aside>

### 고민했던 부분

<aside>

먼저 처음에는 가장 작은 숫자부터 높은 숫자로 가게 만든다고 문제를 잘못 이해했습니다.. 다시 문제를 읽고 큰 수부터 가장 멀리 나갈 수 있을 때까지 재귀를 반복한다는 것을 깨닫고 풀었습니다.
또 산을 깎을 때는 무조건 1만 깎아서 나아갈 곳에 대한 경우의 수를 가장 크게 만들어줍니다.

그리고 개선한 부분이 있는데, 이는 오답 코드를 다시 풀면서 자연스럽게 코드가 바뀌었는데, 매 회차마다 나아갈 수 없는지 체크를 하는 함수를 돌렸습니다. 그런데 그럴 필요 없이 재귀 함수에 나아간 거리를 담고 있으므로 매 회차마다 전역 변수 값을 max로 갱신해주면 되는 일이어서 코드의 중복을 없앴습니다.

</aside>