### PR TITLE
[ADD] Day03 추가

### DIFF
--- a/서가은/Day02/Day02_17298.java
+++ b/서가은/Day02/Day02_17298.java
@@ -1,4 +1,4 @@
-package 서가은.Day2;
+package 서가은.Day02;
 import java.util.*;
 import java.io.*;
 

--- a/서가은/Day03/Day03_13335.java
+++ b/서가은/Day03/Day03_13335.java
@@ -1,0 +1,72 @@
+import java.io.*;
+import java.util.*;
+
+public class Day03_13335 {
+	public static void main(String args[]) throws IOException{
+		
+		
+	//백준 입력
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+
+		//[기본으로 입력 받아야하는 값]		
+		int N = Integer.parseInt(st.nextToken());
+		int W = Integer.parseInt(st.nextToken());
+		int L = Integer.parseInt(st.nextToken());
+
+		String[] input = br.readLine().split(" ");
+		ArrayList<Integer> trucks = new ArrayList<>();	//ArrayList<INTEGER> trucks : 트럭들
+		for (int i=0; i<N; i++) {
+			trucks.add(Integer.parseInt(input[i]));
+		}
+		
+
+		
+		
+	//[다리 배열 관련 변수]
+		
+		//다리 배열, 다리 길이 만큼 0 삽입해두고 시작(아 근데 여기서 메모리 초과 나려나..?), 지금 로직에서는 길이가 동적으로 가니깐 ArrayList
+		ArrayList<Integer> bridge = new ArrayList<>();
+		for(int i=0; i<W; i++) {
+			bridge.add(0);
+		}
+		
+		int bridgeFront = 0; //현재 다리 가장 앞 인덱스
+		int waitNow = 0; //대기열 현재 인덱스
+		int bridgeWeight = 0; //다리 현재 하중
+		int result=0;
+		
+		
+	//[구현]
+		while (waitNow < N) {
+
+			int target = trucks.get(waitNow);
+			int outNext = bridge.get(bridgeFront); // 곧 나갈 애
+//			System.out.printf("대기 맨 앞 트럭 %d   그 다음 대기 %d  ", target,outNext);
+			
+			if(L < (target+bridgeWeight-outNext)) { // 곧 나갈 애를 빼줬어야함..
+				bridge.add(0);
+			}
+			else {
+				bridge.add(target);
+				bridgeWeight+=target;
+				waitNow++;
+			}
+			
+			
+			bridgeWeight-=outNext;
+			bridgeFront++;
+			result++;	
+//			System.out.println(bridge.subList(bridgeFront, bridgeFront+W));
+
+		}
+		
+		//마지막 트럭 이동 하는 것까지 더하기
+		result+=W;
+		System.out.println(result);
+		
+		
+		
+		
+        }	
+}


### PR DESCRIPTION
<aside>

### 문제 풀이 단계

- [x]  문제를 3회독 및 이해
- [x]  문제를 익숙한 용어로 재정의
- [x]  어떻게 해결할지 계획을 세운다.
- [x]  계획을 검증한다.
    - [x]  가장 작은 테케를 가지고 시뮬레이션
    - [x]  시간 복잡도 확인
    - [x]  오픈 테케 및 엣지 테케 만들고 시뮬레이션 및 시간 복잡도 확인
- [x]  문제 풀이
- [x]  어떻게 풀었는지 돌아보고, 개선할 방법이 있는지 찾아본다
</aside>

---

### 문제 풀이

<aside>

**문제 정리**

BOJ 13335. 트럭

[입력]
1. N개의 트럭 : 순서 못 바꿈, 각각의 트럭 무게 다름

2. (w길이, 최대하중 l )의 다리 : 최대 w대 까지만,  다리 올라가 있는 트럭 무게 합 <= l
	(다리 위에 완전히 올라가 있는 트럭만 카운트)

[구현]
길이가 2고 최대하중 10인 다리

[]   [  , ]  [7,4,5,6]
[]   [  , 7] [4,5,6]
[]   [ 7 , ] [4,5,6] //최대하중 10 이내로
[7]   [  , 4] [5,6]
[7]   [ 4 ,5 ] [,6]
[7,4]   [5, ] [6] //최대하중 10 이내로
[7,4,5]   [, 6] []
[7,4,5]   [6, ] []
[7,4,5,6]   [, ] [] //완전히 건너야함

[출력]
모든 트럭이 다리를 건너는 최단시간 구해야함

---

**시간 복잡도 계산**

while문을 하나만 사용하고, result의 크기 만큼 순회하기 때문에 O(n)
****

</aside>

### 고민했던 부분

<aside>

어찌할까?

1. 음... 투포인터 써도 괜찮겠는데
근데 이제 문제는 저 공백일 때 건너는거 좀 조심히 해야하지 않나...?ㅎㅎ,,,
2. 걍 구현 저대로 큐로 구현하는 것도 괜찮은 문젠데
3. 오늘 배운 슬라이딩 윈도우 써도 될 것 같은.. (다리 길이만큼 인덱스 옮기기...)

오 아님 큐 안에서 무게를 투포인터로 합산하는 것도 괜찮은데

대기 배열 = []

다리 배열 = []

완료 배열 = [] //실제론 구현 할 필요 없을 듯

근데 어제 보니깐 대기 배열.isEmpty() 보단
인덱스 참조가 더 시간이 덜 드니깐 인덱스 값 참조 형식으로 크게 for문 돌아보자

---

**주요 로직 - 슬라이딩 윈도우 ( 다리의 길이가 고정되어있기 때문에 선택)**

다리에 올라올 수 있으면 그 값을 더하고,
없으면 0을 더해서 하중 관리,

대기열 다 소모될 때까지 반복문 돌기

//1. 대기열에서 값 하나 지정

//2. 지금 다리 내 현재 값이랑 합산해보기

//3. 합산 값이랑 최대 하중 비교

//3-1. 만약 최대하중 < 합산값

//다리 배열에 0 삽입

//3-2. 아니면

//다리 배열에 현재 대기열 인덱스 값 더하기 

//대기열 인덱스(i) 한칸 옮기기

//4. 인덱스 값 현재 합산 값sum에서 빼기

//5. 다리 인덱스 한 칸 옮기기

//6. 결과++

</aside>

---

### 코드

```java
import java.io.*;
import java.util.*;

public class Day03_13335 {
	public static void main(String args[]) throws IOException{
		
		
	//백준 입력
		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
		StringTokenizer st = new StringTokenizer(br.readLine());

		//[기본으로 입력 받아야하는 값]		
		int N = Integer.parseInt(st.nextToken());
		int W = Integer.parseInt(st.nextToken());
		int L = Integer.parseInt(st.nextToken());

		String[] input = br.readLine().split(" ");
		ArrayList<Integer> trucks = new ArrayList<>();	//ArrayList<INTEGER> trucks : 트럭들
		for (int i=0; i<N; i++) {
			trucks.add(Integer.parseInt(input[i]));
		}
		

		
		
	//[다리 배열 관련 변수]
		
		//다리 배열, 다리 길이 만큼 0 삽입해두고 시작(아 근데 여기서 메모리 초과 나려나..?), 지금 로직에서는 길이가 동적으로 가니깐 ArrayList
		ArrayList<Integer> bridge = new ArrayList<>();
		for(int i=0; i<W; i++) {
			bridge.add(0);
		}
		
		int bridgeFront = 0; //현재 다리 가장 앞 인덱스
		int waitNow = 0; //대기열 현재 인덱스
		int bridgeWeight = 0; //다리 현재 하중
		int result=0;
		
		
	//[구현]
		while (waitNow < N) {

			int target = trucks.get(waitNow);
			int outNext = bridge.get(bridgeFront); // 곧 나갈 애
//			System.out.printf("대기 맨 앞 트럭 %d   그 다음 대기 %d  ", target,outNext);
			
			if(L < (target+bridgeWeight-outNext)) { // 곧 나갈 애를 빼줬어야함..
				bridge.add(0);
			}
			else {
				bridge.add(target);
				bridgeWeight+=target;
				waitNow++;
			}
			
			
			bridgeWeight-=outNext;
			bridgeFront++;
			result++;	
//			System.out.println(bridge.subList(bridgeFront, bridgeFront+W));

		}
		
		//마지막 트럭 이동 하는 것까지 더하기
		result+=W;
		System.out.println(result);
		
		
		
		
        }	
}
```

---

## 개선한 부분

트럭끼리 사회적 거리두기 해버림

<img width="61" height="276" alt="스크린샷 2025-07-24 오후 7 32 05" src="https://github.com/user-attachments/assets/365dd6bf-2252-4dd6-a361-651931aab251" />


[0,0] 중간 중간 배열을 새로운 배열이 들어오기 전까지 아예 스택이 비어버리는 현상 발생

```jsx
if(L < (target+bridgeWeight-outNext)) { // 곧 나갈 애를 빼줬어야함..
```

outNext(이제 나갈 트럭)를 빼주지 않아서 들어오지 못하는 거였음