### PR TITLE
Day04 최지훈

### DIFF
--- a/최지훈/day04/Day04_철도_공사.java
+++ b/최지훈/day04/Day04_철도_공사.java
@@ -1,0 +1,118 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	// 철도 클래스
+	static class Rail {
+		int prevNum = 0;
+		int nextNum = 0;
+		
+		Rail(int prevNum, int nextNum) {
+			this.prevNum = prevNum;
+			this.nextNum = nextNum;
+		}
+	}
+	
+	static int N, M, size;
+	static Rail[] rail;
+	static int[] status;
+	
+	static StringBuilder sb = new StringBuilder();
+	
+	public static void main(String[] args) throws Exception {
+//		System.setIn(new FileInputStream("src/input.txt"));
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		size = 0;
+		
+		rail = new Rail[1000003];
+		status = new int[1000003];
+		st = new StringTokenizer(br.readLine());
+		int[] tmp = new int[N];
+		for(int i=0; i<N; i++) {
+			tmp[i] = Integer.parseInt(st.nextToken());
+			status[tmp[i]] = 1;
+			size++;
+		}
+		
+		// rail 배열에 역 연결
+		for(int i=0; i<N; i++) {
+			int prev = tmp[((i-1) + N)%N];
+			int next = tmp[(i+1)%N];
+			rail[tmp[i]] = new Rail(prev, next);
+		}
+		
+		// 공사 시작
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			String ctr = st.nextToken();
+			int cur = 0;
+			int next = 0;
+			if(ctr.equals("BN") || ctr.equals("BP")) {
+				cur = Integer.parseInt(st.nextToken());
+				next = Integer.parseInt(st.nextToken());
+				railAdd(ctr, cur, next);
+			} else if(size >= 2 && (ctr.equals("CN") || ctr.equals("CP"))) {
+				cur = Integer.parseInt(st.nextToken());
+				railRemove(ctr, cur);
+			}
+		}
+		
+		System.out.println(sb);
+		br.close();
+	}
+	
+	static void railAdd(String ctr, int cur, int next) {
+		// next 이미 설립된 역
+		if(status[next] == 1) return;
+		
+		// 1. cur번호 nextNum역 번호 출력 -> cur과 nextNum 사이에 next 역 추가
+		if(ctr.equals("BN")) {
+			sb.append(rail[cur].nextNum).append("\n");
+			rail[next] = new Rail(cur, rail[cur].nextNum);
+			rail[rail[cur].nextNum].prevNum = next;
+			rail[cur].nextNum = next;
+		}
+		// 2. cur번호 prevNum역 번호 출력 -> cur과 nextNum 사이에 next 역 추가
+		else if(ctr.equals("BP")) {
+			sb.append(rail[cur].prevNum).append("\n");
+			rail[next] = new Rail(rail[cur].prevNum, cur);
+			rail[rail[cur].prevNum].nextNum = next;
+			rail[cur].prevNum = next;
+		}
+		status[next] = 1;
+		size++;
+	}
+	
+	static void railRemove(String ctr, int cur) {
+		// 1. cur번호 nextNum역 번호 출력 -> nextNum 역 폐쇄
+		if(ctr.equals("CN")) {
+			sb.append(rail[cur].nextNum).append("\n");
+			// 현재 위치에서 다다음 역 번호
+			int next = rail[cur].nextNum;
+			int next2 = rail[rail[cur].nextNum].nextNum;
+			rail[next2].prevNum = cur;
+			rail[cur].nextNum = next2;
+			rail[next].prevNum = 0;
+			rail[next].nextNum = 0;
+			status[next] = 0;
+		}
+		// 2. cur번호 prevNum역 번호 출력 -> prevNum 역 폐쇄
+		else if(ctr.equals("CP")) {
+			sb.append(rail[cur].prevNum).append("\n");
+			// 현재 위치에서 전전 역 번호
+			int prev = rail[cur].prevNum;
+			int prev2 = rail[rail[cur].prevNum].prevNum;
+			rail[prev2].nextNum = cur;
+			rail[cur].prevNum = prev2;
+			rail[prev].prevNum = 0;
+			rail[prev].nextNum = 0;
+			status[prev] = 0;
+		}
+		size--;
+	}
+
+}


### PR DESCRIPTION
<aside>

### 문제 풀이 단계

- [x]  문제를 3회독 및 이해
- [x]  문제를 익숙한 용어로 재정의
- [x]  어떻게 해결할지 계획을 세운다.
- [x]  계획을 검증한다.
    - [x]  가장 작은 테케를 가지고 시뮬레이션
    - [x]  시간 복잡도 확인
    - [x]  오픈 테케 및 엣지 테케 만들고 시뮬레이션 및 시간 복잡도 확인
- [x]  문제 풀이
- [x]  어떻게 풀었는지 돌아보고, 개선할 방법이 있는지 찾아본다
</aside>

---

### 문제 풀이

<aside>

**문제 정리**

- 각 역들이 앞 뒤로 연결 되며 원형을 그리는 구조
- 새로운 역이 앞 또는 뒤에 삽입
- 입력으로 들어온 역 앞 또는 뒤의 역을 삭제

---

**시간 복잡도 계산**

- 해당 문제에서는 N이 500,000이고, M이 1,500,000 이기 때문에 N * M 혹은 N* N 만 되어도 2초가 초과
- 따라서 역을 삽입하고 삭제하며 구조를 유지하는 과정이 linkedlist처럼 이루어져야 함
- 처음에 N번 순회하며 역을 넣는 시간 O(N)
- M번 순회하며 삽입 or 삭제 일어나는 시간 → 반복문 x → O(M)
- 따라서 O(N + M) ⇒ 최대 2,000,000
- 하지만 시간이 오래걸리는 이유를 고민해봤는데
    - 삽입, 삭제, 조회에서 해당 데이터에 접근하는데 오래 걸린다고 생각
    - 다 풀고 다른 사람들의 풀이를 봤는데, 클래스 배열이 아닌 기본 자료형 배열로 하더라도 200ms 정도 차이가 나서 큰 의미는 없어보이기도..
</aside>

### 고민했던 부분

<aside>

다 풀고 개선할 점을 고민하다가 HashMap을 사용하면 조회가 빠르지 않을까? 라고 생각했습니다.

적용했지만 시간초과가 났고 이유를 찾아본 결과

1. 배열은 메모리에서 연속적으로 배치되어 캐시 히트율이 높아서 인덱스를 통해 바로 메모리에 접근이 가능
2. HashMap은 해시 계산 → 버킷 접근 → entry 객체 생성 및 참조를 모두 포함하므로 실제 O(1)보다 더 느림
    - java의 HashMap은 Entry 객체 내 키-값 저장 방식으로 배열 접근보다 두 번의 참조 역참조가 발생 → 실행 시간 지연
    - Hash table의 worst case는 O(N)
    - https://en.wikipedia.org/wiki/Associative_array
3. 그리고 위에서 말했듯이, primitive 타입의 배열과 객체 타입의 배열에 대한 성능 차이도 있었습니다.
    - 예를 들어 int[] 같은 경우는 배열 내부에 원시 타입이 들어있으므로 인덱스 접근 시, 바로 주소를 바라보기 때문에 즉시 조회가 되는 반면
    - 객체 배열 같은 경우는 객체로 생성된 배열을 조회하기 위해 힙에 들어갔다가 또 배열 내부에 있는 객체를 조회하기 위해서 힙에 들어간 객체를 한번 더 본 뒤 값을 조회하는 형식이다.
    - 따라서 후자가 더 오래 걸리는 것.
    - https://www.baeldung.com/java-primitives-vs-objects
</aside>