### PR TITLE
Day06 최지훈

### DIFF
--- a/최지훈/day06/Day06_퇴사.java
+++ b/최지훈/day06/Day06_퇴사.java
@@ -1,0 +1,37 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	static int N;
+	static int[] T, P, dp;
+	
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		
+		N = Integer.parseInt(st.nextToken());
+		T = new int[N];
+		P = new int[N];
+		dp = new int[N+1];
+		for(int i=0; i<N; i++) {
+			st = new StringTokenizer(br.readLine());
+			T[i] = Integer.parseInt(st.nextToken());
+			P[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		solve();
+		
+		System.out.print(dp[N]);
+		
+		br.close();
+	}
+	
+	static void solve() {
+		for(int i=0; i<N; i++) {
+			if(i + T[i] <= N) {
+				dp[i + T[i]] = Math.max(dp[i + T[i]], dp[i] + P[i]);
+			}
+			dp[i+1] = Math.max(dp[i], dp[i+1]);
+		}
+	}
+}


### PR DESCRIPTION
<aside>

### 문제 풀이 단계

- [x]  문제를 3회독 및 이해
- [x]  문제를 익숙한 용어로 재정의
- [x]  어떻게 해결할지 계획을 세운다.
- [x]  계획을 검증한다.
    - [x]  가장 작은 테케를 가지고 시뮬레이션
    - [x]  시간 복잡도 확인
    - [x]  오픈 테케 및 엣지 테케 만들고 시뮬레이션 및 시간 복잡도 확인
- [x]  문제 풀이
- [x]  어떻게 풀었는지 돌아보고, 개선할 방법이 있는지 찾아본다
</aside>

---

### 문제 풀이

<aside>

**문제 정리**

1. 주어진 상담 일정에 대해서 최대 이익을 얻을 수 있도록 상담을 잡고 이익을 출력하는 문제
2. i번째 날에 상담을 잡으면 i+T[i] 날 이후에 상담 가능
    - 따라서 i+T[i] 날의 최대 이익은 i번째 날에 상담을 한 경우와 안 한 경우로 나눠 볼 수 있음
    - 이를 점화식으로 표현하면 dp[i+T[i]] = Math.max(dp[i+T[i]], dp[i] + P[i]); 이다
    - 이때 i값을 탐색하고 i+1 값을 탐색할 때 i에서의 계산을 기억해야 최댓값을 유지하므로 i+1 번째에 max(i 번째 값, i+1번째 값)을 넣음

---

**시간 복잡도 계산**

- N번만 반복하므로 O(N) = 15
</aside>

### 고민했던 부분

<aside>

dp로 문제를 해결하려고 했습니다. 처음에는 dp[i+T[i]] = Math.max(dp[i+T[i]], dp[i] + P[i]) 만 고려해서 계산했는데, 제대로 된 값이 나오지 않았습니다. 최대 수익을 다음 일정에 넣고 있으므로 다음 인덱스에는 해당 인덱스의 최댓값을 받아오지 못하고 있습니다. 따라서 i+1 번째 인덱스에 max(i 번째 값, i+1번째 값)을 넣어줘서 인덱스를 이동하며 최댓값을 유지해줬습니다.
```
for(int i=0; i<N; i++) {
	// i + T[i] 날짜에 max(기존 i+T[i]날의 값, i번째 이익 추가)
	if(i + T[i] <= N) {
		dp[i + T[i]] = Math.max(dp[i + T[i]], dp[i] + P[i]);
	}
	/*
          * 위의 코드로만 진행하면 예제 input에 대해서
          * [0, 0, 0, 10, 30, 0, 45, 0]
          * 라는 dp 값이 나옴
          * => (i + T[i]) 날에 i번째 날의 상담 이익이 들어가 있지만,
          * => 해당 날 이전까지의 이익이 반영되지 않은 구간도 있음
          * => 즉, 상담을 하지 않은 날(dp[i+1])에도 이전까지의 최대 이익(dp[i])을 갱신해줘야 함
          * => 그래야 상담을 건너뛰고 다음 날로 넘어갈 경우의 최댓값이 유지됨
          */
	dp[i+1] = Math.max(dp[i], dp[i+1]);
}
```

</aside>