### PR TITLE
Day11 이주미

### DIFF
--- a/이주미/day11/Day11_우주신과의교감.java
+++ b/이주미/day11/Day11_우주신과의교감.java
@@ -1,0 +1,147 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Day11_우주신과의교감 {
+	
+	private static int N, M;
+	private static Node[] nodes;
+	private static int[] parent;
+	private static int[] rank;
+	private static Queue<Edge> pq;
+	private static List<Edge> list;
+	private static int edgeCnt;
+	
+	public static class Node{
+		int x, y;
+		int idx;
+	}
+	
+	public static class Edge implements Comparable<Edge>{
+		Node endNode1, endNode2;
+		double weight;
+		Edge(Node endNode1, Node endNode2, double weight){
+			this.endNode1 = endNode1;
+			this.endNode2 = endNode2;
+			this.weight = weight;
+		}
+		@Override
+		public int compareTo(Edge e) {
+			return Double.compare(this.weight, e.weight);
+		}
+	}
+	
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		StringBuilder sb = new StringBuilder();
+		
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		
+		parent = new int[N+1];
+		rank = new int[N+1];
+		for(int i=1; i<=N; i++) {
+			parent[i] = i;
+			rank[i] = 1;
+		}
+		
+		// N개 노드 입력
+		nodes = new Node[N+1];
+		for(int i=1; i<=N; i++) {
+			st = new StringTokenizer(br.readLine());
+			nodes[i] = new Node();
+			
+			nodes[i].idx = i;
+			nodes[i].x = Integer.parseInt(st.nextToken());
+			nodes[i].y = Integer.parseInt(st.nextToken());
+		}
+		
+		// M개 간선 입력
+		for(int i=0; i<M; i++) {
+			st = new StringTokenizer(br.readLine());
+			int from = Integer.parseInt(st.nextToken());
+			int to = Integer.parseInt(st.nextToken());
+			
+			// 추가된 간선 입력 받으면서 동시에 parent 노드들 갱신
+			if(find(from) != find(to)) {
+				union(from, to);
+				edgeCnt++;
+			}
+		}
+		
+		// 노드 기준으로 모든 간선 생성
+		pq = new PriorityQueue<>();
+//		list = new ArrayList<>();
+		for(int i=1; i<N; i++) {
+			Node n1 = nodes[i];
+			for(int j=i+1; j<=N; j++) {
+				Node n2 = nodes[j];
+				
+				// 두 노드가 이미 입력받은 간선이 아니라면 추가
+				if(find(i) != find(j)) {
+					pq.add(new Edge(n1, n2, calcW(n1, n2)));
+//					list.add(new Edge(n1, n2, calcW(n1, n2)));
+				}
+			}
+		}
+		
+		System.out.printf("%.2f\n", kruskal());
+	}
+	
+	private static double kruskal() {
+		double edgeLength=0;
+		
+		while(!pq.isEmpty()) {
+//			System.out.printf("[%f] pq.size: %d\n", edgeLength, pq.size());
+			Edge e = pq.poll();
+			int pn1 = find(e.endNode1.idx);
+			int pn2 = find(e.endNode2.idx);
+//			System.out.printf("   pn1: %d, pn2: %d\n", pn1, pn2);
+			
+			// 새로 연결해야 하는 노드일 때
+			if(pn1 != pn2) {
+				union(pn1, pn2);
+				edgeLength += e.weight;
+				edgeCnt++;
+			}
+			
+			if(edgeCnt >= N-1) break;
+		}
+		
+		return edgeLength;
+	}
+	
+	private static int find(int node) {
+		if(parent[node] == node) {
+			return node;
+		}
+		return parent[node] = find(parent[node]);
+	}
+	
+	private static void union(int n1, int n2) {
+		int pn1 = find(n1);
+		int pn2 = find(n2);
+		
+		// pn1이 더 큰 트리의 부모 : pn1으로 합치기
+		if(rank[pn1] < rank[pn2]) {
+			int temp = pn1;
+			pn1 = pn2;
+			pn2 = temp;
+		}
+		
+		parent[pn2] = pn1;
+		rank[pn1]+= rank[pn2];
+	}
+	
+	private static double calcW(Node n1, Node n2) {
+		return Math.sqrt(Math.pow(n1.x-n2.x, 2) + Math.pow(n1.y-n2.y, 2));
+	}
+
+}


### PR DESCRIPTION
<aside>

### 문제 풀이 단계

- [x]  문제를 3회독 및 이해
- [x]  문제를 익숙한 용어로 재정의
- [x]  어떻게 해결할지 계획을 세운다.
- [ ]  계획을 검증한다.
    - [x]  가장 작은 테케를 가지고 시뮬레이션
    - [ ]  시간 복잡도 확인
    - [ ]  오픈 테케 및 엣지 테케 만들고 시뮬레이션 및 시간 복잡도 확인
- [x]  문제 풀이
- [x]  어떻게 풀었는지 돌아보고, 개선할 방법이 있는지 찾아본다
</aside>

---

### 문제 풀이

<aside>

**문제 정리**

- 하… 이제 하다하다 우주신이랑 교감한단다…
- N개의 노드(우주신)
M개의 이미 연결된 간선(비용 = 노드 간의거리)
- 모든 노드가 연결되도록 간선 새로 만들기
- 새로 추가되는 간선 길이의 합을 반환: 소수점 둘째자리까지 반올림

---

**시간 복잡도 계산**

- rank도 같이 써서 pq 관리함
- 1) 간선 생성 : N^2 * logN
2) kruskal : 모든 간선에 대해 poll (logN) ⇒ N^2*logN
⇒ O(N*N*logN)
</aside>

### 고민했던 부분

<aside>

- 초기 구현
    - 어제 했던 Union-Find는 이미 간선들이 있을 때
    → 그 중에서 진짜 연결할 간선을 추가로 선택하는 거였음
    - 이 문제는 간선을 있다고 봐야 하는지? 애매함…
    : 노드들은 고정됐기 때문에 간선이 이미 있다고 봐도 되는 것 같은데
    : 그럼 모든 노드x모든 노드에 대해서 간선을 만들라고? 그럴리가 없잖아
        - 여기서는 노드간의 거리가 곧 비용과 같음.
        즉 신규 간선을 연결할 때는 최소 거리를 갖는 노드를 연결하는 게 핵심으로 보이는데
        : 델타 써서 가장 주변에 있는 노드를 찾아야 되나
        : 솔직히 이거 아니고서는 지금 생각이 안 남
        - 근데 좌표 크기가 가로x세로 몇인지 커스텀으로 주어지지 않음
        : 이차원 배열 map 위에 노드 기록하는 형태는 아닌 듯 한데
        : 그럼 델타 써서 해당 위치에 노드가 있는지 못 찾지 않나?
        : 걍 max로 10^6*10^6 때려버려 ..? 아니잖아 그런 거
        - 배열 크기 max로 때려버릴 바에 ..
        노드가 최대 10^3개니까 모든 노드 x 모든 노드 간선 만들어버리는 게 나을 것 같음
    - 모든 노드들 간의 간선을 만들어서 관리한다고 할 때
        - 입력된 노드들 먼저 저장  : [X, Y]의 Node
        - 저장된 모든 노드 기준으로 간선 생성하고 PQ에 넣은 다음
        → 추가된 간선을 union 처리해야 하나?
        : 추가된 간선을 PQ에서 찾아서 제거해야 하는데
        : 찾는 contains 메서드가 시간복잡도 O(N)이니까 찾고지우고를간선만큼한다고?
        - 추가된 간선까지 읽고 먼저 union 처리한 다음
        → 저장된 모든 노드 기준으로 간선 생성하면?
        : 이미 추가된 간선에 대해서도 생성하는 걸 방지해야 되는데 어떻게 하지
        : find써서 검증하면 될 듯 이게 더 나을 것 같다
    - 일단 한 번 해보자… 맞는지 보자..
- 2차 구현
    - 정렬 기준이 되는 weight가 실수형이라서 compareTo를 override할 때
    Double.compare(this.weight, e.weight);를 사용해야 함
    - 연결되는 간선 수를 count 할 때
    : 초기 입력받는 간선의 개수인 M으로 초기화를 하면 안됨
    : 그 안에서도 겹치는 게 있을 수 있기 때문에
    : 전역변수로 간선 수를 관리하고 & 입력받는 간선을 연결하는 union 작업을 할 때 ++
</aside>

---