### PR TITLE
[feat][백준] 5639. 이진 검색 트리

### DIFF
--- a/전경원/day15/Day15_이진검색트리.java
+++ b/전경원/day15/Day15_이진검색트리.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+    static int[] pre;
+    static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        List<Integer> list = new ArrayList<>();
+        String line;
+        while ((line = br.readLine()) != null) {
+            line = line.trim();
+            if (line.isEmpty()) continue;
+            list.add(Integer.parseInt(line));
+        }
+
+        pre = new int[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+        	pre[i] = list.get(i);
+        }
+
+        solve(0, pre.length);
+
+        System.out.print(sb);
+    }
+
+    static void solve(int s, int e) {
+        if (s >= e) return;
+
+        int root = pre[s];
+        int m = s + 1;
+
+        while (m < e && pre[m] < root) m++;
+
+        solve(s + 1, m);
+        solve(m, e);
+
+        sb.append(root).append('\n');
+    }
+}


### PR DESCRIPTION
<aside>

### 문제 풀이 단계

- [x]  문제를 3회독 및 이해
- [x]  문제를 익숙한 용어로 재정의
- [x]  어떻게 해결할지 계획을 세운다.
- [ ]  계획을 검증한다.
    - [x]  가장 작은 테케를 가지고 시뮬레이션
    - [ ]  시간 복잡도 확인
    - [ ]  오픈 테케 및 엣지 테케 만들고 시뮬레이션 및 시간 복잡도 확인
- [x]  문제 풀이
- [ ]  어떻게 풀었는지 돌아보고, 개선할 방법이 있는지 찾아본다
</aside>

---

### 문제 풀이

<aside>

**문제 정리**

이진 검색 트리를 전위 순회한 결과가 주어지면 후위 순회한 결과로 바꿔서 출력하는 문제.

---

**시간 복잡도 계산**

</aside>

### 고민했던 부분

<aside>

어떤 식으로 루트 노드와 왼쪽, 오른쪽 노드를 구분할 수 있을지 고민했다.

일단 첫 번째 값을 루트 노드로 설정한 후에 나머지 배열에 대해 반복문을 돌면서 루트보다 커지는 부분을 기록해서 왼쪽과 오른쪽으로 나눴다. 

전위 순회는 루트 왼쪽 오른쪽 순으로 순회하기 때문에  처음 루트의 값보다 큰 값이 나오면 거기서부터가 오른쪽인 것이다.

이렇게 왼쪽, 오른쪽을 구하고 후위 순회의 결과 값을 출력했다.

근데 좀 헷갈려서 파이썬으로 먼저 풀고 자바로 고쳤습니다 ㅎㅎ

앞으로는 자바로 한번에 풀 수 있게 해봐야겠다.

</aside>