### PR TITLE
Day24 오남의

### DIFF
--- a/nameui/day24/Day24_캐시.java
+++ b/nameui/day24/Day24_캐시.java
@@ -1,0 +1,50 @@
+import java.util.*;
+import java.io.*;
+
+class Solution {
+    
+    static ArrayList<String> cacheList;
+    
+    public int solution(int cacheSize, String[] cities) {
+        int answer = 0;
+        
+        // 실제 동적으로 사용할 캐시(조회용)
+        cacheList = new ArrayList<>(cacheSize);
+        
+        // 캐시 사이즈가 아예 0 인 경우도 처리해주기
+        if(cacheSize == 0) {
+            answer = cities.length * 5;
+            return answer;
+        }
+
+        for(int i = 0; i<cities.length; i++) {
+            String nowCity = cities[i].toLowerCase();
+            
+            // 캐시 먼저 탐색. cache 가 비어있지 않고, 캐시에 현재 도시가 있는 경우.
+            if(!cacheList.isEmpty() && cacheList.contains(nowCity)) {
+                cacheList.remove(nowCity);
+                cacheList.add(nowCity);
+                answer += 1; // 캐시가 존재하므로 1 더하기.
+                continue;
+            }
+
+            // 캐시에 없고, 캐시가 다 차지 않음.
+            if(cacheList.size() < cacheSize) { // 캐시 다 찾을 때
+                // 캐시가 다 안 찼으면, 마지막에 추가하기
+                cacheList.add(nowCity);
+                answer += 5;
+                continue;
+            }
+            
+            // 캐시에 없고, 캐시가 다 참.
+            // 캐시에서 도시 지우기
+            cacheList.remove(cacheList.get(0));
+            // 캐시에 새로운 도시 추가하기
+            cacheList.add(nowCity);
+            answer += 5;
+            
+        }
+        
+        return answer;
+    }
+}


### PR DESCRIPTION
<aside>

### 문제 풀이 단계

- [x]  문제를 3회독 및 이해
- [x]  문제를 익숙한 용어로 재정의
- [x]  어떻게 해결할지 계획을 세운다.
- [x]  계획을 검증한다.
    - [x]  가장 작은 테케를 가지고 시뮬레이션
    - [x]  시간 복잡도 확인
    - [ ]  오픈 테케 및 엣지 테케 만들고 시뮬레이션 및 시간 복잡도 확인
- [x]  문제 풀이
- [x]  어떻게 풀었는지 돌아보고, 개선할 방법이 있는지 찾아본다
</aside>

---

#문제 풀이

- 지도에서 도시 이름 검색하면 해당 도시아 관련된 맛집 게시물들을 DB 에서 읽어 보여주는 서비스 개발
- DB 캐시를 적용하여 성능 개선 시도하고 있지만 캐시 크기를 얼마로 해야 효율적인지 몰라 난감한 상황.
- DB 캐시를 적용할 때 캐시 크기에 따른 실행 시간 측정 프로그램 작성

[입력]
- cacheSize : 정수 0 ~ 30
- cities : 도시 이름으로 이뤄진 문자열 배열, 최대 도시 수 10^5개
- 각 도시 이름은 영문자로만 구성되어 있고, 대소문자 구분하지 않음.
- 도시 이름 최대 20자로 이루어짐.
- 입력된 도시이름 배열을 순서대로 처리할 때 "총 실행 시간 출력"
- LRU 캐시 교체 알고리즘 사용 : Least Recently Used
- 가장 최근에 사용하지 않았던 것을 순서대로 제거하는 알고리즘.
- 즉, 가장 나중에 사용된 순으로 제거
- cache hit 일 경우 실행시간 1 - 캐시에 찾는 데이터가 있을 경우
- cache miss 일 경우 실행시간 5 - 캐시에 찾는 데이터가 없는 경우

[예제 분석]

1. Jeju -> 5 -> 캐시 [Jeju]
2. Pangyo -> 10 -> 캐시 [Jeju, Pangyo]
3. Seoul -> 15 -> 캐시 [Jeju, Pangyo, Seoul]
4. NewYork -> 20 -> 캐시 [Pangyo, Seoul, NewYork]
5. LA -> 25 -> 캐시 [Seoul, NewYork, LA]
6. Jeju -> 30 -> 캐시 [NewYork, LA, Jeju]
7. Pangyo -> 35 -> 캐시 [Pangyo, LA, Jeju]
8. Seoul -> 40 -> 캐시 [LA, Jeju, Seoul]
9. NewYork -> 45 -> 캐시 [Jeju, Seoul, NewYork]
10. LA -> 50 -> 캐시 [Seoul, NewYork, LA]

## 문제 풀이 과정

1. 완전탐색
    - Data 라는 객체 생성
        - 멤버 변수는 도시 이름, 마지막 방문 시간이 있음
    - 캐시 제거할 때는 우선순위 큐 사용하고, 캐시 중 있는지 찾을 때는 해시 맵 사용.
    - 여기서 중요한 것이 캐시 제거할 때 해시 맵에 캐시 같이 삭제해주기. 찾을 때는 해시 맵 사용해서 마지막으로 사용한 시간 변경해주기
    - 그리고 캐시에 있으면, 1 누적 후 큐와 해시 맵에는 변동 없고, Data 객체에 마지막 사용 시간만 변동 / 없으면 5 누적 후 우선순위 큐에 추가 및 해시 맵에서 우선순위 큐에서 꺼낸 것 삭제하기.
    - [최종 로직]
        
        Data(String city, int lastTime)
        
        캐시 맵 : 도시 이름이 key, Data 가 value
        
        캐시 우선순위 큐 : Data 타입으로 넣고, 마지막 사용 시간 오름차순으로 정렬
        
        1. 맵과 큐 크기 캐시 최대 크기로 설정.
        2. for 문 돌면서 전체 데이터 순회
            - 현재 원소가 캐시에 있으면 바로 1 누적하고, City 의 time 현재 t 로 바꿔주고(객체이므로 바로 정렬될듯..?) 바로 다음 원소로
            - 현재 원소가 캐시에 없으면 바로 5 누적하고, 우선순위 큐에서 poll 한 객체 캐시 맵에서도 지워주기. 그리고 현재 t 반영해서 현재 원소 우선순위 큐에 넣어주고, 캐시 맵에도 추가. 그리고 다음 원소로
        
- 틀렸던 이유 : 캐시에 있어서 사용했으면 다시 순서를 맨 뒤로 바꿔줘야 했는데, 그 로직을 빼먹음..
